### PR TITLE
Implement HTTPS redirect and HSTS security headers

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,12 @@ from app.exception_handlers import (
     rate_limit_handler,
 )
 from app.logging_config import get_logger
-from app.middleware import LoggingMiddleware, RateLimitMiddleware, SecurityHeadersMiddleware
+from app.middleware import (
+    HTTPSRedirectMiddleware,
+    LoggingMiddleware,
+    RateLimitMiddleware,
+    SecurityHeadersMiddleware,
+)
 from app.routes import auth, main, scrolls
 from app.security.nonce_middleware import NonceMiddleware
 
@@ -68,6 +73,8 @@ app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(LoggingMiddleware)
 # Nonce middleware must run before SecurityHeadersMiddleware to generate nonces
 app.add_middleware(NonceMiddleware)
+# HTTPS redirect should be one of the first to run (added last)
+app.add_middleware(HTTPSRedirectMiddleware)
 
 # Disable rate limiting during tests
 is_testing = os.getenv("TESTING", "").lower() in ("true", "1", "yes")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ async def client(test_db):
     app.dependency_overrides[get_db] = override_get_db
 
     # Use httpx AsyncClient with the app's ASGI callable
-    async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as ac:
+    async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="https://test") as ac:
         yield ac
 
     # Clean up

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -51,6 +51,7 @@ def test_server():
     # Set up test environment
     os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///:memory:"
     os.environ["TESTING"] = "1"
+    os.environ["E2E_TESTING"] = "1"  # Disable HTTPS redirect for E2E tests
 
     # Override the database connection in the app
     TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -1,0 +1,62 @@
+"""Security tests for HTTPS redirect and security headers."""
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+async def test_security_headers_present(test_server):
+    """Test that security headers are present in E2E test responses."""
+    # E2E tests disable HTTPS redirect, so we get normal responses with security headers
+    async with httpx.AsyncClient(follow_redirects=False) as client:
+        response = await client.get(test_server)
+
+        # Should get normal response (E2E testing disables HTTPS redirect)
+        assert response.status_code == 200
+
+        # Check for important security headers
+        headers = response.headers
+
+        # X-Frame-Options prevents clickjacking
+        assert headers.get("x-frame-options") is not None
+
+        # X-Content-Type-Options prevents MIME sniffing
+        assert headers.get("x-content-type-options") is not None
+
+        # X-XSS-Protection (legacy but still good to have)
+        x_xss_protection = headers.get("x-xss-protection")
+        if x_xss_protection:  # Optional header
+            assert x_xss_protection in ["1; mode=block", "0"]
+
+
+async def test_hsts_header_present_on_simulated_https(test_server):
+    """Test that HSTS header is present when simulating HTTPS via proxy header."""
+    # This test simulates an HTTPS request by setting x-forwarded-proto header
+    # In production with a reverse proxy, this header would be set automatically
+    async with httpx.AsyncClient(follow_redirects=False) as client:
+        # Simulate request through HTTPS proxy
+        headers = {"x-forwarded-proto": "https"}
+        response = await client.get(test_server, headers=headers)
+
+        # Should get normal response with HSTS (E2E testing still allows proxy HTTPS detection)
+        assert response.status_code == 200
+
+        # Check for HSTS header
+        hsts = response.headers.get("strict-transport-security")
+        assert hsts is not None
+        assert "max-age=31536000" in hsts
+        assert "includeSubDomains" in hsts
+
+
+async def test_hsts_header_not_present_on_http(test_server):
+    """Test that HSTS header is NOT present on HTTP responses."""
+    async with httpx.AsyncClient(follow_redirects=False) as client:
+        response = await client.get(test_server)
+
+        # Should get normal response (E2E testing, no redirect)
+        assert response.status_code == 200
+
+        # HSTS header should NOT be present on HTTP responses
+        hsts = response.headers.get("strict-transport-security")
+        assert hsts is None

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,35 @@
+"""Unit tests for security headers middleware."""
+
+from httpx import AsyncClient
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_hsts_header_on_https_unit_test(client: AsyncClient):
+    """Test that HSTS header is present on HTTPS unit test responses."""
+    # Unit tests use https://test base URL, so HTTPS scheme is detected
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+
+    # Should have HSTS header since unit tests use HTTPS base URL
+    hsts = response.headers.get("strict-transport-security")
+    assert hsts is not None
+    assert "max-age=31536000" in hsts
+    assert "includeSubDomains" in hsts
+
+
+@pytest.mark.asyncio
+async def test_security_headers_present_unit_test(client: AsyncClient):
+    """Test that all security headers are present on unit test responses."""
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+
+    # Check all security headers
+    headers = response.headers
+    assert headers.get("x-frame-options") == "DENY"
+    assert headers.get("x-content-type-options") == "nosniff"
+    assert headers.get("x-xss-protection") == "1; mode=block"
+    assert headers.get("referrer-policy") == "strict-origin-when-cross-origin"
+    assert headers.get("strict-transport-security") is not None


### PR DESCRIPTION
## Summary
- Implements HTTP to HTTPS redirect middleware with 301 status codes
- Adds Strict-Transport-Security (HSTS) header with 1-year duration and includeSubDomains
- Updates test infrastructure to work with HTTPS enforcement
- Includes comprehensive security header testing

## Security Enhancements
- **HTTPS Redirect**: All HTTP requests automatically redirected to HTTPS
- **HSTS Header**: Browser remembers to use HTTPS for 1 year, prevents downgrade attacks
- **Security Headers**: X-Frame-Options, X-Content-Type-Options, X-XSS-Protection on all responses
- **Proxy Support**: Handles x-forwarded-proto header for reverse proxy setups

## Test Infrastructure Updates
- Unit tests now use HTTPS base URLs (`https://test`)
- E2E tests disable HTTPS redirect to avoid SSL certificate complexity
- Comprehensive security header testing for both environments
- HSTS proxy simulation testing

## Test Plan
- [x] Unit tests pass with HTTPS client
- [x] E2E tests pass with HTTP server (redirect disabled)
- [x] Security headers present on all response types
- [x] HSTS header only on HTTPS responses
- [x] Proxy HTTPS detection works correctly
- [x] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)